### PR TITLE
Fixed outdated Discord link

### DIFF
--- a/index.html
+++ b/index.html
@@ -32,7 +32,7 @@
 			<li><a href="https://forum.telefang.net/" target="_blank" data-caption="Come visit the forum, Tulunk Village."><img src="img/icon-forum.png" alt="Forum"><span>Forum</span></a></li>
 			<li><a href="https://manga.telefang.net/" target="_blank" data-caption="We're scanlating the manga. You can read it here."><img src="img/icon-manga2.png" alt="Manga"><span>Manga</span></a></li>
 			<li><a href="https://www.redbubble.com/people/racieb/collections/375968-telefang" target="_blank" data-caption="Buy some cool Telefang-related stuff and help the host out!"><img src="img/store-icons/random.php" alt="Store"><span>Store</span></a></li>
-			<li><a href="https://discord.gg/fQkCY" data-caption="Come chat with us!"><img src="img/icon-chat.png" alt="Chat"><span>Chat</span></a></li>
+			<li><a href="https://discord.gg/tD8jTVa4TT" data-caption="Come chat with us!"><img src="img/icon-chat.png" alt="Chat"><span>Chat</span></a></li>
 		</ul>
 	</section>
 	


### PR DESCRIPTION
This Discord link takes new users to #telefang, is unlimited, and does not expire.